### PR TITLE
Config Manager Iterator

### DIFF
--- a/src/Config.jl
+++ b/src/Config.jl
@@ -15,7 +15,7 @@ include("Save.jl")
 
 # Base Class
 include("Manager.jl")
-export ConfigManager, total_combinations, add!, parse!,
+export ConfigManager, iterator, total_combinations, add!, parse!,
     get_sweep_params, param_setting_from_id, params_with, param_values,
     get_datafile, get_stepslog, get_expdir, get_logdir,
     log_config, get_subconfig, get_attrs,


### PR DESCRIPTION
- Added an iterator for the config manager. Loops over all param combos and num runs with a convenience struct. 
- Added function iterator to the exports for convenience in creating an _CM_Iterator
- Added a copy function for the CM to return a copy of the CM. We deeply copy any internal dictionaries to avoid parse! race conditions/issues.
