### PR TITLE
Updated iterator to include job_id as well

### DIFF
--- a/src/Manager.jl
+++ b/src/Manager.jl
@@ -81,7 +81,7 @@ function Base.iterate(iter::_CM_Iterator, state=(1,1))
     cm = copy(iter.manager)
 
     parse!(cm, state[1], state[2])
-    return cm, new_state
+    return ((state[1]-1)*iter.num_runs + state[2], cm), new_state
     
 end
 


### PR DESCRIPTION
I've added the job_id to the iterator to make integration a bit easier. This is how exceptions are captured when running in parallel.